### PR TITLE
Fix sshparser

### DIFF
--- a/nornir_paramiko/plugins/connections/__init__.py
+++ b/nornir_paramiko/plugins/connections/__init__.py
@@ -48,12 +48,13 @@ class Paramiko:
         }
 
         user_config = ssh_config.lookup(hostname)
-        for k in ("hostname", "user", "port"):
+
+        for k in ("hostname",  "port"):
             if k in user_config:
-                if k == "user":
-                    parameters["username"] = user_config["user"]
-                else:
                     parameters[k] = user_config[k]
+        if "user" in user_config:
+            parameters["username"] = user_config["user"]
+
 
         if "proxycommand" in user_config:
             parameters["sock"] = paramiko.ProxyCommand(user_config["proxycommand"])

--- a/nornir_paramiko/plugins/connections/__init__.py
+++ b/nornir_paramiko/plugins/connections/__init__.py
@@ -48,9 +48,12 @@ class Paramiko:
         }
 
         user_config = ssh_config.lookup(hostname)
-        for k in ("hostname", "username", "port"):
+        for k in ("hostname", "user", "port"):
             if k in user_config:
-                parameters[k] = user_config[k]
+                if k == "user":
+                    parameters["username"] = user_config["user"]
+                else:
+                    parameters[k] = user_config[k]
 
         if "proxycommand" in user_config:
             parameters["sock"] = paramiko.ProxyCommand(user_config["proxycommand"])

--- a/nornir_paramiko/plugins/tasks/paramiko_sftp.py
+++ b/nornir_paramiko/plugins/tasks/paramiko_sftp.py
@@ -27,7 +27,7 @@ def get_src_hash(filename: str) -> str:
 def get_dst_hash(task: Task, filename: str) -> str:
     command = "sha1sum {}".format(filename)
     try:
-        result = paramiko_command.remote_command(task, command)
+        result = paramiko_command(task, command)
         if result.stdout is not None:
             return result.stdout.split()[0]
 


### PR DESCRIPTION
 Nornir uses "username" as key to log devices while ssh_config file use "User".
 This fix will translate "User" ssh_config  key to "Username"